### PR TITLE
Bump down com.google.android.material:material from 1.13.0 to 1.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.activity:activity:1.11.0'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.googlecode.libphonenumber:libphonenumber:9.0.14'
     implementation project(path: ':securesmsproxyapi')


### PR DESCRIPTION
com.google.android.material:material 1.13.0 triggers a malware alarm by Ikarus and Google VT-Checks