### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -69,6 +69,8 @@ jobs:
 
   deploy-aar:
 
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/frimtec/secure-sms-proxy/security/code-scanning/6](https://github.com/frimtec/secure-sms-proxy/security/code-scanning/6)

To fix the issue, add an explicit `permissions` block to the `deploy-aar` job with the minimum required privileges. The job appears to upload artifacts to a release using `actions/upload-release-asset@v1`, which requires `contents: write` to edit releases and upload assets. Therefore, we only need to grant `contents: write` for this job. This addition should be made directly under the `deploy-aar:` block, above `runs-on: ubuntu-22.04` (in parallel to the structure of the other jobs in the workflow).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
