### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buid.yml
+++ b/.github/workflows/buid.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     name: Build and Test
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/frimtec/secure-sms-proxy/security/code-scanning/4](https://github.com/frimtec/secure-sms-proxy/security/code-scanning/4)

To address this issue, you should add a `permissions` key to the `build` job, mirroring the minimal example and matching the `apk` job. Add `permissions: contents: read` directly below `name: Build and Test` for the `build` job. This ensures that the `GITHUB_TOKEN` for this job has only read access to repository contents—adequate for building, testing, and uploading coverage reports, unless more is required. No changes are required elsewhere or to other YAML structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
