### PR TITLE
Improve application rule management

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Build S2MSP on your own and then install the APK via ADB to your android phone.
 S2MSP provides an easy API to integrate applications. The API supports the registration process, sending and receiving SMS,
 as well as querying if specific phone numbers are already granted for the application.
 
+### Open an Issue to get your application registered with S2MSP
+That S2MSP can show the name and the icon of your app it must be registered in the S2MSP `AndroidManifest.xml`.
+You can open an issue on this project with the following information:
+* Link to your application project.
+* Android package name of your application.
+
 ### Adding the library to your project
 The API is provided as an AAR (Android Archive) file and is available on [Maven Central][maven-central].
 You can add the following dependency to your application project:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
         tools:ignore="UnnecessaryRequiredFeature" />
 
     <queries>
+        <!-- Add all applications that are compatible with S2MSP so that name and icon can be displayed. -->
+        <package android:name="com.github.frimtec.android.pikettassist" />
+
         <intent>
             <action android:name="com.github.frimtec.android.securesmsproxy.SMS_RECEIVED" />
         </intent>

--- a/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/ApplicationRuleArrayAdapter.java
+++ b/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/ApplicationRuleArrayAdapter.java
@@ -1,7 +1,6 @@
 package com.github.frimtec.android.securesmsproxy.ui;
 
 import android.content.Context;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,14 +15,13 @@ import androidx.annotation.Nullable;
 import com.github.frimtec.android.securesmsproxy.R;
 import com.github.frimtec.android.securesmsproxy.domain.Application;
 import com.github.frimtec.android.securesmsproxy.domain.ApplicationRule;
-import com.github.frimtec.android.securesmsproxy.service.PhoneNumberFormatter;
 import com.github.frimtec.android.securesmsproxy.utility.PackageInfoAccessor;
 import com.github.frimtec.android.securesmsproxyapi.utility.PhoneNumberType;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 class ApplicationRuleArrayAdapter extends ArrayAdapter<ApplicationRule> {
 
@@ -58,16 +56,7 @@ class ApplicationRuleArrayAdapter extends ArrayAdapter<ApplicationRule> {
       }
       label.setText(labelText);
       TextView phoneNumbers = convertView.findViewById(R.id.application_allowed_phone_numbers);
-      String networkCountryIso = PhoneNumberType.networkCountryIso(getContext());
-      Set<String> allowedPhoneNumbers = applicationRule.allowedPhoneNumbers();
-      phoneNumbers.setText(
-          allowedPhoneNumbers
-              .stream()
-              .map(number -> PhoneNumberFormatter.getFormattedNumber(number, networkCountryIso))
-              .filter(number -> !TextUtils.isEmpty(number))
-              .sorted()
-              .collect(Collectors.joining("\n"))
-      );
+      phoneNumbers.setText(String.format(Locale.getDefault(), "%d", applicationRule.allowedPhoneNumbers().size()));
 
       ImageButton deleteButton = convertView.findViewById(R.id.application_button_delete);
       deleteButton.setOnClickListener(deleteAction.apply(this, applicationRule));

--- a/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/ApplicationRuleDetailActivity.java
+++ b/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/ApplicationRuleDetailActivity.java
@@ -3,6 +3,7 @@ package com.github.frimtec.android.securesmsproxy.ui;
 import android.app.AlertDialog;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -90,6 +91,25 @@ public class ApplicationRuleDetailActivity extends BaseActivity {
     EditText input = new EditText(this);
     input.setInputType(InputType.TYPE_CLASS_TEXT);
     input.setHint(R.string.application_rule_detail_phone_number_hint);
+    input.setFilters(new InputFilter[]{(source, start, end, dest, dstart, dend) -> {
+      boolean startsWithPlus = (dstart == 0 && end > start && source.charAt(start) == '+') ||
+          (dstart > 0 && dest.length() > 0 && dest.charAt(0) == '+');
+      for (int i = start; i < end; i++) {
+        char c = source.charAt(i);
+        if (c == '+') {
+          if (dstart > 0 || i > start) {
+            return "";
+          }
+        } else if (startsWithPlus) {
+          if (!Character.isDigit(c)) {
+            return "";
+          }
+        } else if (!Character.isLetterOrDigit(c)) {
+          return "";
+        }
+      }
+      return null;
+    }});
 
     AlertDialog dialog = new AlertDialog.Builder(this)
         .setTitle(R.string.application_rule_detail_add_phone_number_title)

--- a/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/MainActivity.java
+++ b/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/MainActivity.java
@@ -93,25 +93,33 @@ public class MainActivity extends BaseActivity {
         .map(rule -> rule.application().name())
         .collect(Collectors.toSet());
 
-    List<String> installedPackages = packageInfoAccessor.getInstalledPackages().stream()
+    List<String> packageOptionsToAdd = packageInfoAccessor.getInstalledPackages().stream()
         .filter(packageName -> !packageName.equals(getPackageName()))
         .filter(packageName -> !packageInfoAccessor.isSystemApp(packageName))
         .filter(packageName -> !alreadyRegistered.contains(packageName))
         .sorted(Comparator.comparing(packageName -> packageInfoAccessor.getLabel(packageName).toString().toLowerCase()))
         .collect(Collectors.toList());
 
-    new AlertDialog.Builder(this)
-        .setTitle(R.string.main_add_application_title)
-        .setAdapter(new AppArrayAdapter(this, installedPackages), (dialog, which) -> {
-          String selectedPackage = installedPackages.get(which);
-          dao.insertOrUpdate(selectedPackage, "", Collections.emptySet(), new PhoneNumberFormatter(this));
-          refresh();
-          Intent intent = new Intent(this, ApplicationRuleDetailActivity.class);
-          intent.putExtra(ApplicationRuleDetailActivity.EXTRA_APPLICATION_NAME, selectedPackage);
-          startActivity(intent);
-        })
-        .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss())
-        .show();
+    if(packageOptionsToAdd.isEmpty()) {
+      new AlertDialog.Builder(this)
+          .setTitle(R.string.main_add_application_title)
+          .setMessage(R.string.main_no_applications_found)
+          .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss())
+          .show();
+    } else {
+      new AlertDialog.Builder(this)
+          .setTitle(R.string.main_add_application_title)
+          .setAdapter(new AppArrayAdapter(this, packageOptionsToAdd), (dialog, which) -> {
+            String selectedPackage = packageOptionsToAdd.get(which);
+            dao.insertOrUpdate(selectedPackage, "", Collections.emptySet(), new PhoneNumberFormatter(this));
+            refresh();
+            Intent intent = new Intent(this, ApplicationRuleDetailActivity.class);
+            intent.putExtra(ApplicationRuleDetailActivity.EXTRA_APPLICATION_NAME, selectedPackage);
+            startActivity(intent);
+          })
+          .setNegativeButton(android.R.string.cancel, (dialog, which) -> dialog.dismiss())
+          .show();
+    }
   }
 
   @Override

--- a/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/PhoneNumberArrayAdapter.java
+++ b/app/src/main/java/com/github/frimtec/android/securesmsproxy/ui/PhoneNumberArrayAdapter.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
@@ -35,8 +36,16 @@ class PhoneNumberArrayAdapter extends ArrayAdapter<String> {
     }
     String phoneNumber = getItem(position);
     if (phoneNumber != null) {
-      TextView phoneNumberText = convertView.findViewById(R.id.phone_number_text);
       String networkCountryIso = PhoneNumberType.networkCountryIso(getContext());
+      PhoneNumberType type = PhoneNumberType.fromNumber(phoneNumber, networkCountryIso);
+      ImageView typeIcon = convertView.findViewById(R.id.phone_number_type_icon);
+      typeIcon.setImageResource(switch (type) {
+        case STANDARD, NUMERIC_SHORT_CODE -> R.drawable.swap_vert_24px;
+        case ALPHANUMERIC_SHORT_CODE -> R.drawable.south_24px;
+        case EMPTY -> 0;
+      });
+
+      TextView phoneNumberText = convertView.findViewById(R.id.phone_number_text);
       phoneNumberText.setText(PhoneNumberFormatter.getFormattedNumber(phoneNumber, networkCountryIso));
 
       ImageButton deleteButton = convertView.findViewById(R.id.phone_number_delete);

--- a/app/src/main/res/drawable/south_24px.xml
+++ b/app/src/main/res/drawable/south_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M320,520ZM600,880L400,680L457,624L560,727L560,440L640,440L640,727L743,624L800,680L600,880Z"/>
+</vector>

--- a/app/src/main/res/drawable/swap_vert_24px.xml
+++ b/app/src/main/res/drawable/swap_vert_24px.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M320,520L320,233L217,336L160,280L360,80L560,280L503,336L400,233L400,520L320,520ZM600,880L400,680L457,624L560,727L560,440L640,440L640,727L743,624L800,680L600,880Z"/>
+</vector>

--- a/app/src/main/res/layout/application_rule_item.xml
+++ b/app/src/main/res/layout/application_rule_item.xml
@@ -37,7 +37,8 @@
         android:layout_centerVertical="true"
         android:layout_marginStart="5dp"
         android:layout_toStartOf="@+id/application_button_delete"
-        android:textSize="15sp" />
+        android:textSize="18sp"
+        android:textStyle="bold"/>
 
     <ImageButton
         android:id="@+id/application_button_delete"

--- a/app/src/main/res/layout/phone_number_item.xml
+++ b/app/src/main/res/layout/phone_number_item.xml
@@ -1,14 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="10dp">
+
+    <ImageView
+        android:id="@+id/phone_number_type_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="10dp"
+        android:contentDescription="@null"
+        app:srcCompat="@drawable/ic_android_24dp" />
 
     <TextView
         android:id="@+id/phone_number_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
+        android:layout_toEndOf="@id/phone_number_type_icon"
         android:layout_centerVertical="true"
         android:textSize="18sp" />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -22,7 +22,7 @@ Aufgrund neuer Sideloading-Einschränkungen auf Android 15 und höher muss \"Ein
   <string name="send_log_button_send">Senden</string>
   <string name="action_delete">Löschen</string>
   <string name="header_application">Applikation</string>
-  <string name="header_phone_numbers">Erlaubte Nummern</string>
+  <string name="header_phone_numbers">Anzahl zulässiger Nummern</string>
   <string name="register_comment">Die genannte Applikation verlangt die Berechtigung SMS via S2MSP zu empfangen und zu senden, eingeschränkt auf folgende Telefonnummern:</string>
   <string name="register_reject">Ablehnen</string>
   <string name="register_allow">Erlauben</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -22,7 +22,7 @@ En raison des nouvelles restrictions de chargement latéral sur Android 15 et ve
   <string name="send_log_button_send">Envoyer</string>
   <string name="action_delete">Effacer</string>
   <string name="header_application">Application</string>
-  <string name="header_phone_numbers">Numéros autorisés</string>
+  <string name="header_phone_numbers">Compte des numéros autorisés</string>
   <string name="register_comment">L\'application indiquée demande des autorisations pour envoyer et recevoir des SMS via S2MSP limités aux numéros de téléphone suivants:</string>
   <string name="register_reject">Rejeter</string>
   <string name="register_allow">Permettre</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -22,7 +22,7 @@ A causa delle nuove restrizioni sul sideload su Android 15 e versioni successive
   <string name="send_log_button_send">Inviare</string>
   <string name="action_delete">Elimina</string>
   <string name="header_application">Applicazione</string>
-  <string name="header_phone_numbers">Numeri consentiti</string>
+  <string name="header_phone_numbers">Conteggio numeri consentiti</string>
   <string name="register_comment">L\'applicazione indicata richiede le autorizzazioni per inviare e ricevere SMS tramite S2MSP limitate ai seguenti numeri di telefono:</string>
   <string name="register_reject">Rifiutare</string>
   <string name="register_allow">Permettere</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@ Due to new sideloading restrictions on Android 15 and above, \"Allow restricted 
   <string name="send_log_button_send">Send</string>
   <string name="action_delete">Delete</string>
   <string name="header_application">Application</string>
-  <string name="header_phone_numbers">Allowed numbers</string>
+  <string name="header_phone_numbers">Allowed numbers count</string>
   <string name="register_comment">The stated application requests permissions to send and receive SMS via S2MSP restricted to the following phone numbers:</string>
   <string name="register_reject">Reject</string>
   <string name="register_allow">Allow</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,5 @@ Due to new sideloading restrictions on Android 15 and above, \"Allow restricted 
   <string name="application_rule_detail_add_phone_number_title">Add number</string>
   <string name="application_rule_detail_phone_number_hint">Number</string>
   <string name="main_add_application_title">Add application</string>
+  <string name="main_no_applications_found">No suitable applications found!</string>
 </resources>


### PR DESCRIPTION
* Restrict number input
* Register known clients for package queries to support display of app name and icon
* Add icons to visualize supported send/receive support of specific number types
* Only show total count of authorized numbers in overview
* Explicitly show if no suitable application is found to add